### PR TITLE
add packages.txt with eslint packages

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -3,3 +3,4 @@ compile-cache/
 storage/
 nohup.out
 .apm
+packages

--- a/README.md
+++ b/README.md
@@ -7,6 +7,7 @@ $ cd ~
 # If you have an atom config already:
 $ mv .atom .atom-bak
 $ git clone git@github.com:substantial/substantial-atomfiles.git .atom
+$ apm install --packages-file ~/.atom/packages.txt
 ```
 
 ## Goal

--- a/config.cson
+++ b/config.cson
@@ -3,3 +3,6 @@
     userId: "53c5f869-8a29-d7f5-ef48-bc598612bb8d"
   welcome:
     showOnStartup: false
+  core: {}
+  editor:
+    invisibles: {}

--- a/packages.txt
+++ b/packages.txt
@@ -1,0 +1,2 @@
+linter
+linter-eslint

--- a/packages/README.md
+++ b/packages/README.md
@@ -1,1 +1,0 @@
-All packages in this directory will be automatically loaded


### PR DESCRIPTION
From what I can tell, we have two options when it comes to committing packages. We can either list the packages in a packages.txt and have to install them whenever we update, or we can actually commit the contents of `packages/`.

There are downsides and upsides to each.

If we use packages.txt: 
- package versions may get out of sync (maybe we can code that in?)
- installing a package via the UI would no longer cause the git dir to be dirty, so people could be running packages that aren't part of the repo and not know it

If we commit the packages dir:
- The repo will be much larger and take longer to clone (though probably faster than cloning and apm installing)
- Everyone would be on the same version of everything

I'm somewhat leaning towards just comitting the packages dir, at least until there's a better option than packages.txt.
