### PR TITLE
add update-packages script

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -3,3 +3,4 @@ compile-cache/
 storage/
 nohup.out
 .apm
+packages

--- a/README.md
+++ b/README.md
@@ -7,6 +7,7 @@ $ cd ~
 # If you have an atom config already:
 $ mv .atom .atom-bak
 $ git clone git@github.com:substantial/substantial-atomfiles.git .atom
+$ cd .atom && bin/update-packages
 ```
 
 ## Goal

--- a/README.md
+++ b/README.md
@@ -3,11 +3,11 @@
 ## Installation instructions
 
 ```bash
-$ cd ~
+cd ~
 # If you have an atom config already:
-$ mv .atom .atom-bak
-$ git clone git@github.com:substantial/substantial-atomfiles.git .atom
-$ cd .atom && bin/update-packages
+mv .atom .atom-bak
+git clone git@github.com:substantial/substantial-atomfiles.git .atom
+cd .atom && bin/update-packages
 ```
 
 ## Goal
@@ -25,3 +25,44 @@ This is an experiment. We want to see if we can build a config that we enjoy tha
 * This config should be usable in all operating systems that Atom supports.
 * It is never done. It should be refined, added to  and optimized indefinitely.
 * Be mindful of the fact that others use this config. If you have good reason to make huge changes, communicate them and seek advice on them. We shouldn't worry about backwards compatability too much, but we should be mindful.
+
+## Packages
+
+### How to install a new package
+
+#### Via the command line
+
+1. Install `my-new-package`:
+
+   ```bash
+   ~/.atom/bin/install-package my-new-package
+   ```
+2. Commit the change to `packages.txt` and pull request it.
+
+#### Via the UI
+
+1. Use the Install section of preferences to install a package.
+2. Run:
+
+    ```bash
+    ~/.atom/bin/update-packages
+    ```
+3. Answer "keep" when asked about your package.
+4. Commit the change to `packages.txt` and pull request it.
+
+### How to upgrade packages
+
+1. Use the UI to update packages.
+2. Run:
+
+    ```bash
+    ~/.atom/bin/update-packages
+    ```
+3. Commit the changes to `package.txt` and pull request it.
+
+### Installed
+
+[Linter](https://atom.io/packages/linter) - Enable displaying lint (code style)
+warnings.
+[linter-eslint](https://atom.io/packages/linter-eslint) - Linter plugin for
+[eslint](https://atom.io/packages/linter-eslint)

--- a/bin/install-package
+++ b/bin/install-package
@@ -1,0 +1,5 @@
+#!/usr/bin/env bash
+set -e
+
+apm install $1
+apm list --installed --bare > ~/.atom/packages.txt

--- a/bin/update-packages
+++ b/bin/update-packages
@@ -7,6 +7,10 @@ def main
   installed = parse_package_list(`apm list --installed --bare`)
   packages_txt = parse_package_list(File.read(PACKAGES_TXT))
 
+  packages_to_remove(packages_txt, installed).each do |name, _|
+    system("apm uninstall #{name}")
+  end
+
   # Install only updated or missing packages
   packages_to_install(packages_txt, installed).each do |name, version|
     system("apm install #{name}@#{version}")
@@ -16,6 +20,10 @@ def main
   `apm list --installed --bare > #{PACKAGES_TXT}`
 
   puts "Done!"
+end
+
+def packages_to_remove(packages_txt, installed)
+  installed.reject { |name, _| packages_txt.key?(name) }
 end
 
 def packages_to_install(packages_txt, installed)

--- a/bin/update-packages
+++ b/bin/update-packages
@@ -1,0 +1,41 @@
+#!/usr/bin/env ruby
+
+PATH = File.expand_path('../..', __FILE__)
+PACKAGES_TXT = File.join(PATH, "packages.txt")
+
+def main
+  installed = parse_package_list(`apm list --installed --bare`)
+  packages_txt = parse_package_list(File.read(PACKAGES_TXT))
+
+  # Install only updated or missing packages
+  packages_to_install(packages_txt, installed).each do |name, version|
+    system("apm install #{name}@#{version}")
+  end
+
+  # Write new packages.txt
+  `apm list --installed --bare > #{PACKAGES_TXT}`
+
+  puts "Done!"
+end
+
+def packages_to_install(packages_txt, installed)
+  packages_txt.select { |name, version|
+    !installed.key?(name) ||
+      Gem::Version.new(version) > Gem::Version.new(installed[name])
+  }
+end
+
+def parse_package_list(list)
+  list.lines
+    .map(&:strip)
+    .reject(&:empty?)
+    .map { |line| parse_package(line.strip) }
+    .to_h
+end
+
+def parse_package(line)
+  name, version = line.split("@")
+  [name, version]
+end
+
+main if __FILE__ == $PROGRAM_NAME

--- a/bin/update-packages
+++ b/bin/update-packages
@@ -8,6 +8,11 @@ def main
   packages_txt = parse_package_list(File.read(PACKAGES_TXT))
 
   packages_to_remove(packages_txt, installed).each do |name, _|
+    puts "Found package \"#{name}\" that is not in packages.txt."
+    puts "If you installed this and want to keep it, type \"keep\": "
+    line = readline.chomp
+    next if line == "keep"
+
     system("apm uninstall #{name}")
   end
 

--- a/config.cson
+++ b/config.cson
@@ -3,3 +3,6 @@
     userId: "53c5f869-8a29-d7f5-ef48-bc598612bb8d"
   welcome:
     showOnStartup: false
+  core: {}
+  editor:
+    invisibles: {}

--- a/packages.txt
+++ b/packages.txt
@@ -1,3 +1,3 @@
-linter@1.2.0
+linter@1.2.3
 linter-eslint@1.0.18
 

--- a/packages.txt
+++ b/packages.txt
@@ -1,0 +1,3 @@
+linter@1.2.0
+linter-eslint@1.0.18
+

--- a/packages/README.md
+++ b/packages/README.md
@@ -1,1 +1,0 @@
-All packages in this directory will be automatically loaded


### PR DESCRIPTION
Ok, this may work. The `update-packages` script will look at installed packages and what is in your package.txt and install the latest then resync packages.txt. This should keep versions in sync. Removing packages will require uninstalling the package and deleting it from packages.txt.

My thinking was that we could still use the UI to install packages and update them at the cost of it being slightly trickier to remove packages.

Of course, now that I think about it, removing packages won't really work on more than one computer. If I remove a package, how would your machine know to remove it? It'd just add it back. Soooo.. maybe I just make it so that it can only update versions, but it will actually uninstall packages that were installed via the UI that aren't in the packages.txt? 

This probably won't be a huge deal if we wrote a plugin for it... there's some prior art here, but I didn't like any of them:

https://github.com/lee-dohm/package-sync
https://atom.io/packages/parcel
