### PR TITLE
enable autosave

### DIFF
--- a/config.cson
+++ b/config.cson
@@ -11,3 +11,5 @@
   "linter-eslint":
     disableWhenNoEslintrcFileInPath: true
   react: {}
+  autosave:
+    enabled: true


### PR DESCRIPTION
Opening this for discussion purposes. This autosave isn't exactly what I'm used to, which is it essentially saves as you type (well, when you go back to normal mode in vim), but it is an autosave of sorts.

This will save whenever atom or a pane loses focus. In other words, only one file can be modified at a time. It may be annoying in Guard/`--watch`'d things, but less annoying than the vim version.

Thoughts?
