### PR TITLE
add block-travel package

### DIFF
--- a/README.md
+++ b/README.md
@@ -80,3 +80,6 @@ This is an experiment. We want to see if we can build a config that we enjoy tha
   * `ctrl-o (` - Select around parens, can use any of: `[{('"<t`
 * [language-haml](https://atom.io/packages/language-haml) - HAML support
 * [react](https://atom.io/packages/language-haml) - React support
+* [block-travel](https://atom.io/packages/block-travel) - Move the cursor by code blocks
+  * `alt-n` - Scroll down by blocks
+  * `alt-p` - Scroll up by blocks

--- a/keymap.cson
+++ b/keymap.cson
@@ -26,9 +26,8 @@
 
 # window/pane navigation
 'body, atom-text-editor':
-  'alt-p': 'window:focus-previous-pane'
-  'alt-n': 'window:focus-next-pane'
-  'alt-å': 'window:focus-next-pane' # this is how os x sends alt-n
+  'shift-cmd-k': 'window:focus-previous-pane'
+  'shift-cmd-j': 'window:focus-next-pane'
   'cmd-k cmd-h': 'pane:split-left'
   'cmd-k cmd-j': 'pane:split-down'
   'cmd-k cmd-k': 'pane:split-up'
@@ -62,3 +61,11 @@
   'ctrl-o "': 'expand-region:select-around-double-quotes'
   'ctrl-o `': 'expand-region:select-around-back-ticks'
   'ctrl-o t': 'expand-region:select-around-tags'
+
+  # block-travel
+  'alt-p': 'block-travel:move-up'
+  'alt-n': 'block-travel:move-down'
+  'alt-å': 'block-travel:move-down' # this is how os x sends alt-n sometimes
+  'alt-Å': 'block-travel:move-down' # this is how os x sends alt-n sometimes
+  'alt-shift-p': 'block-travel:select-up'
+  'alt-shift-n': 'block-travel:select-down'

--- a/packages.txt
+++ b/packages.txt
@@ -1,3 +1,4 @@
+block-travel@1.0.2
 expand-region@0.2.2
 language-haml@0.21.0
 linter@1.2.3


### PR DESCRIPTION
This moves the alt-n/alt-p from next/previous pane to be block travel up/down. This follows the emacs philosophy (since alt-n does something similar to ctrl-n, just bigger).

Next/prev pane are now cmd+shift j/k which is still home row and hopefully easy enough to hit.
