### PR TITLE
change default font to inconsolata-g

### DIFF
--- a/config.cson
+++ b/config.cson
@@ -5,6 +5,7 @@
     showOnStartup: false
   editor:
     invisibles: {}
+    fontFamily: " Inconsolata-g, Menlo, Consolas, 'DejaVu Sans Mono', monospace"
   tabs:
     usePreviewTabs: true
   core: {}


### PR DESCRIPTION
The default font was Menlo, which is pretty good. I think I prefer Inconsolata-g (though after using Menlo for a while it wasn't too bad...) This will only affect people that have Inconsolata-g installed, and maybe they all want to use it :)

I realize this may be a more controversial one, so I'll wait for some feedback before merging.
