### PR TITLE
Disable autosave

### DIFF
--- a/config.cson
+++ b/config.cson
@@ -14,7 +14,7 @@
     lintOnEdit: false
   react: {}
   autosave:
-    enabled: true
+    enabled: false
   "advanced-new-file":
     showFilesInAutoComplete: true
     suggestCurrentFilePath: true


### PR DESCRIPTION
Our team collectively dislikes this feature. We have a watch that runs our test on every change and this becomes troublesome with autosave.

If this is generally liked, then we need a way to have project specific config 
