### PR TITLE
Remove advanced new file

### DIFF
--- a/README.md
+++ b/README.md
@@ -164,3 +164,5 @@ Z                               | Stash |
 * [tabularize](https://atom.io/packages/tabularize) - Align code
 * [lazy-motion](https://atom.io/packages/lazy-motion) - Rapid cursor
   positioning w/ fuzzy search.
+* [find-and-till](https://atom.io/packages/find-and-till) - Quickly jump to a
+  character on your current line (like Vim's find and till)

--- a/README.md
+++ b/README.md
@@ -148,9 +148,7 @@ Z                               | Stash |
 ### Installed
 
 * [advanced-open-file](https://atom.io/packages/advanced-open-file) - A more
-  reasonable file open with tab completion.
-* [advanced-new-file](https://atom.io/packages/advanced-new-file) - A more
-  reasonable new file with tab completion.
+  reasonable file open/new with tab completion.
 * [color-picker](https://atom.io/packages/color-picker) - Adds a color picker.
 * [pigments](https://atom.io/packages/pigments) - Displays colors in projects
   and files.

--- a/config.cson
+++ b/config.cson
@@ -15,9 +15,6 @@
   react: {}
   autosave:
     enabled: true
-  "advanced-new-file":
-    showFilesInAutoComplete: true
-    suggestCurrentFilePath: true
   "language-babel":
     babelStage: 1
     disableWhenNoBabelrcFileInPath: true

--- a/keymap.cson
+++ b/keymap.cson
@@ -37,6 +37,7 @@
   'alt-k': 'window:focus-pane-above'
   'alt-j': 'window:focus-pane-below'
   'ctrl--': 'tree-view:toggle'
+  'cmd-alt-n': 'advanced-open-file:toggle'
 
 '.fuzzy-finder atom-text-editor[mini]':
   'ctrl-v': 'pane:split-right'

--- a/packages.txt
+++ b/packages.txt
@@ -1,4 +1,3 @@
-advanced-new-file@0.4.3
 advanced-open-file@0.8.1
 block-travel@1.0.2
 color-picker@2.0.11
@@ -8,7 +7,7 @@ foldername-tabs@0.1.4
 git-plus@5.2.2
 language-babel@0.10.2
 language-haml@0.21.0
-lazy-motion@0.1.11
+lazy-motion@0.1.13
 linter@1.2.4
 linter-eslint@3.0.1
 pigments@0.9.0


### PR DESCRIPTION
@bronson pointed out that advanced open file can create new files too. I kept the other binding just because.
