### PR TITLE
Add pane-split-moves-tab

### DIFF
--- a/README.md
+++ b/README.md
@@ -166,3 +166,6 @@ Z                               | Stash |
   positioning w/ fuzzy search.
 * [find-and-till](https://atom.io/packages/find-and-till) - Quickly jump to a
   character on your current line (like Vim's find and till)
+* [pane-split-moves-tab](https://atom.io/packages/pane-split-moves-tab) -
+  Opening a new split moves the current file to that split instead of
+  duplicating it.

--- a/packages.txt
+++ b/packages.txt
@@ -10,6 +10,7 @@ language-haml@0.21.0
 lazy-motion@0.1.13
 linter@1.2.4
 linter-eslint@3.0.1
+pane-split-moves-tab@0.0.2
 pigments@0.9.0
 react@0.12.6
 tabularize@0.2.5


### PR DESCRIPTION
This is something @radamant was talking about the other day, it changes the behavior of opening splits from the editor (but doesn't change opening splits from the fuzzy finder)
