### PR TITLE
Add recent files fuzzy finder

### DIFF
--- a/README.md
+++ b/README.md
@@ -45,6 +45,7 @@ Key                             | Command | Preview
 &nbsp;                          | |
                                 | **Fuzzy File Finder** |
 &#x2318;P                       | Open Fuzzy File Finder |
+&#x2318;B                       | Open Fuzzy File Finder for recently opened files |
 &#x2303;S                       | Open file in horizontal split |
 &#x2303;V                       | Open file in vertical split |
 &nbsp;                          | |
@@ -172,3 +173,5 @@ Z                               | Stash |
 * [pane-split-moves-tab](https://atom.io/packages/pane-split-moves-tab) -
   Opening a new split moves the current file to that split instead of
   duplicating it.
+* [recent-files-fuzzy-finder](https://atom.io/packages/recent-files-fuzzy-finder) -
+  See recently opened files in a Fuzzy Finder dialog

--- a/keymap.cson
+++ b/keymap.cson
@@ -96,3 +96,6 @@
   # clip-history
   'ctrl-y': 'clip-history:paste'
   'ctrl-shift-y': 'clip-history:paste-last'
+
+'atom-workspace':
+  'cmd-b': 'recent-files-fuzzy-finder:toggle-finder'

--- a/packages.txt
+++ b/packages.txt
@@ -15,6 +15,7 @@ linter-eslint@3.0.2
 pane-split-moves-tab@0.0.2
 pigments@0.9.2
 react@0.12.6
+recent-files-fuzzy-finder@0.1.4
 tabularize@0.2.5
 toggle-quotes@0.11.0
 


### PR DESCRIPTION
https://github.com/viddo/recent-files-fuzzy-finder

Allows you to see recently opened files via ALT-SHIFT-T. I've also mapped it to CMD-B since this provides all of the same functionality as the existing CMD-B and more.
