### PR TITLE
add project-find-navigation

### DIFF
--- a/README.md
+++ b/README.md
@@ -92,6 +92,15 @@ Key                             | Command | Preview
 &#x21E7;&#x2318;L               | Split Selection into Multiple Cursors - Turns a selection of multiple lines into separate selections/multiple cursors. Try hitting &#x2303;A afterwards to get the cursors to the beginning of the lines |
 &#x2318;Click                   | Add Cursor - Good for quickly adding multiple cursors for multiple changes in places that would be tricky with find or &#x2318;D |
 &nbsp;                          | |
+                                | **Find and Replace** |
+&#x2318;F                       | Find in File |
+&#x2318;G                       | Find Next in File |
+&#x21E7;&#x2318;G               | Find Previous in File |
+&#x21E7;&#x2318;F               | Find in Project |
+&#x2303;&#x2318;N               | Find Next in Project | ![project-find-navigation](https://cloud.githubusercontent.com/assets/8588/9000934/bc40cda4-3704-11e5-8287-8c5481f09f0f.gif)
+&#x2303;&#x2318;P               | Find Previous in Project |
+&#x21E7;&#x2303;&#x2318;F       | Focus Find in Project Results |
+&nbsp;                          | |
                                 | **Git (git plus)** | ![git-plus](https://cloud.githubusercontent.com/assets/12339/8751823/8b38209a-2c64-11e5-8041-aa803b1dd8b6.gif)
 &#x21E7;&#x2318;H               | Open up git plus fuzzy find (try typing 'checkout' to see options) |
 
@@ -143,6 +152,8 @@ Key                             | Command | Preview
 * [advanced-open-file](https://atom.io/packages/advanced-open-file) - A more
   reasonable file open/new with tab completion.
 * [color-picker](https://atom.io/packages/color-picker) - Adds a color picker.
+* [project-find-navigation](https://atom.io/packages/project-find-navigation) -
+  Quickly navigate project find
 * [pigments](https://atom.io/packages/pigments) - Displays colors in projects
   and files.
 * [Linter](https://atom.io/packages/linter) - Enable displaying lint (code

--- a/config.cson
+++ b/config.cson
@@ -13,8 +13,6 @@
     disableWhenNoEslintrcFileInPath: true
     lintOnEdit: false
   react: {}
-  autosave:
-    enabled: false
   "language-babel":
     babelStage: 1
     disableWhenNoBabelrcFileInPath: true
@@ -23,6 +21,8 @@
   "clip-history": {}
   "file-icons":
     tabPaneIcon: false
+  "find-and-replace":
+    openProjectFindResultsInRightPane: true
 ".cs.source":
   editor:
     tabLength: 4

--- a/keymap.cson
+++ b/keymap.cson
@@ -101,3 +101,13 @@
   # clip-history
   'ctrl-y': 'clip-history:paste'
   'ctrl-shift-y': 'clip-history:paste-last'
+
+# project-find-navigation
+'.preview-pane.project-find-navigation':
+  'ctrl-cmd-n': 'project-find-navigation:select-next-and-confirm'
+  'ctrl-cmd-p': 'project-find-navigation:select-prev-and-confirm'
+
+'atom-workspace atom-text-editor:not([mini])':
+  'ctrl-cmd-n': 'project-find-navigation:next'
+  'ctrl-cmd-p': 'project-find-navigation:prev'
+  'ctrl-cmd-shift-f': 'project-find-navigation:activate-results-pane'

--- a/packages.txt
+++ b/packages.txt
@@ -3,7 +3,7 @@ block-travel@1.0.2
 clip-history@0.1.11
 color-picker@2.0.11
 expand-region@0.2.2
-file-icons@1.6.1
+file-icons@1.6.2
 find-and-till@1.0.2
 foldername-tabs@0.1.5
 git-plus@5.2.2
@@ -15,6 +15,7 @@ linter@1.2.4
 linter-eslint@3.0.2
 pane-split-moves-tab@0.0.2
 pigments@0.9.2
+project-find-navigation@0.0.9
 react@0.12.6
 tabularize@0.2.5
 toggle-quotes@0.11.0


### PR DESCRIPTION
There's no built in way to navigate "find in project" with the keyboard. This adds a way.
