### PR TITLE
Broaden auto-indent selector to make it work again.

### DIFF
--- a/keymap.cson
+++ b/keymap.cson
@@ -83,12 +83,14 @@
   'ctrl-shift-o `': 'expand-region:select-around-back-ticks'
   'ctrl-shift-o t': 'expand-region:select-around-tags'
 
+'atom-text-editor':
+  # auto-indent
+  'ctrl-i': 'editor:auto-indent'
+
 'atom-workspace atom-text-editor:not([mini])':
   # override snippets:available
   'shift-alt-s': 'find-and-till:select-till'
 
-  # auto-indent
-  'ctrl-i': 'editor:auto-indent'
 
   # block-travel
   'alt-p': 'block-travel:move-up'


### PR DESCRIPTION
I noticed `ctrl-i` was no longer auto-indenting. This change seems to fix it.
