### PR TITLE
Add painless panes

### DIFF
--- a/README.md
+++ b/README.md
@@ -55,6 +55,7 @@ Key                | Command | Preview
                    | **Window Navigation** |
 ⇧⌘K                | Focus Previous Pane |
 ⇧⌘J                | Focus Next Pane |
+⌥⌃P                | Toggle automatic pane resizing |
 &nbsp;             | |
                    | **Editing** |
 ⌃I                 | Auto Indent |
@@ -165,9 +166,11 @@ Key                | Command | Preview
   positioning w/ fuzzy search.
 * [find-and-till](https://atom.io/packages/find-and-till) - Quickly jump to a
   character on your current line (like Vim's find and till)
+* [painless-panes](https://atom.io/packages/painless-panes) - Automatically resize panes
 * [clip-history](https://atom.io/packages/clip-history) - Paste from clipboard history like emacs' kill-ring
 * [pane-split-moves-tab](https://atom.io/packages/pane-split-moves-tab) -
   Opening a new split moves the current file to that split instead of
   duplicating it.
 * [recent-files-fuzzy-finder](https://atom.io/packages/recent-files-fuzzy-finder) -
   See recently opened files in a Fuzzy Finder dialog
+

--- a/config.cson
+++ b/config.cson
@@ -23,6 +23,7 @@
     tabPaneIcon: false
   "find-and-replace":
     openProjectFindResultsInRightPane: true
+  "painless-panes": {}
 ".cs.source":
   editor:
     tabLength: 4

--- a/keymap.cson
+++ b/keymap.cson
@@ -25,6 +25,9 @@
 # https://github.com/bevry/cson#what-is-cson
 
 # window/pane navigation
+'body':
+  'ctrl-alt-p': 'painless-panes:toggle'
+
 'body, atom-text-editor':
   'shift-cmd-k': 'window:focus-previous-pane'
   'shift-cmd-j': 'window:focus-next-pane'

--- a/packages.txt
+++ b/packages.txt
@@ -6,13 +6,14 @@ expand-region@0.2.2
 file-icons@1.6.3
 find-and-till@1.0.2
 foldername-tabs@0.1.5
-git-plus@5.3.3
+git-plus@5.3.4
 language-babel@0.11.3
 language-haml@0.21.0
 language-jade@0.6.2
 lazy-motion@0.1.13
 linter@1.3.4
 linter-eslint@3.0.2
+painless-panes@0.1.0
 pane-split-moves-tab@0.0.2
 pigments@0.9.3
 project-find-navigation@0.0.9


### PR DESCRIPTION
This is something I missed from vim, but it may be controverisial. 
It automatically resizes the active pane to a reasonable size and disables standard pane resizing.
You can hit ctrl-alt-p to turn it off entirely.

Thoughts on this? Should it be on by default?
