### PR TITLE
add set-syntax package, bump package versions

### DIFF
--- a/README.md
+++ b/README.md
@@ -177,4 +177,5 @@ Key                | Command | Preview
   Work within doc blocks like jsdoc.
 * [wallaby](https://atom.io/packages/atom-wallaby) -
   Instant test runner for javascript http://wallabyjs.com/
+* [set-syntax](https://atom.io/packages/set-syntax) - Set file syntax with command palette
 

--- a/packages.txt
+++ b/packages.txt
@@ -1,4 +1,4 @@
-advanced-open-file@0.9.1
+advanced-open-file@0.9.2
 atom-wallaby@1.0.4
 auto-update-packages@1.0.0
 block-travel@1.0.2
@@ -10,18 +10,19 @@ file-icons@1.6.9
 find-and-till@1.0.2
 foldername-tabs@0.1.5
 git-plus@5.4.7
-language-babel@0.13.2
+language-babel@0.13.6
 language-haml@0.21.0
 language-jade@0.6.2
 lazy-motion@0.1.13
-linter@1.5.0
+linter@1.5.1
 linter-eslint@3.0.2
 painless-panes@0.1.0
 pane-split-moves-tab@0.0.2
-pigments@0.13.2
+pigments@0.14.0
 project-find-navigation@0.0.9
-react@0.12.6
+react@0.12.8
 recent-files-fuzzy-finder@0.1.4
+set-syntax@0.3.0
 tabularize@0.2.5
 toggle-quotes@0.11.3
 


### PR DESCRIPTION
This just adds a command to set syntax for a file without having to click the syntax link at the bottom of the editor.
